### PR TITLE
Move stuff around in startup docs

### DIFF
--- a/documentation/startup/index.markdown
+++ b/documentation/startup/index.markdown
@@ -40,35 +40,49 @@ Index with some FAQ questions that are answered in the chapter:
 
 ## 1\. First steps
 
-And example how to add servers:
+IRC Networks are made of servers, and servers have channels. The default config has a few predefined networks, to list them:
 
-(OFTC network, identify with nickserv and wait for 2 seconds before joining channels)
+     /NETWORK LIST
 
+And to connect to one of those networks and join a channel:
 
-     /NETWORK ADD -autosendcmd "/^msg nickserv ident pass;wait 2000" OFTC
+     /CONNECT Freenode
+     /JOIN #irssi
 
+To add more networks:
 
-(NOTE: use /IRCNET with 0.8.9 and older)
+     /NETWORK ADD ExampleNet
 
-Then add some servers to different networks (network is already set up for them), irc.kpnqwest.fi is used by default for IRCNet but if it fails, irc.funet.fi is tried next:
+Then add some servers (with -auto to automatically connect):
 
+     /SERVER ADD -auto -network ExampleNet irc.example.net
 
-     /SERVER ADD -auto -network IRCnet irc.kpnqwest.fi 6667
-     /SERVER ADD -network IRCnet irc.funet.fi 6667
-     /SERVER ADD -auto -network efnet efnet.cs.hut.fi 6667
+Automatically join to channels after connected to server:
 
+     /CHANNEL ADD -auto #lounge ExampleNet
 
-Automatically join to channels after connected to server, send op request to bot after joined to efnet/#irssi:
+To modify existing networks (or servers, or channels) just ADD again using the same name as before. This configures a network to identify with nickserv and wait for 2 seconds before joining channels:
 
+     /NETWORK ADD -autosendcmd "/^msg nickserv ident pass;wait 2000" ExampleNet
 
-     /CHANNEL ADD -auto #irssi IRCnet
-     /CHANNEL ADD -auto -bots *!*bot@host.org -botcmd "/^msg $0 op pass" #irssi efnet
+If you have irssi 0.8.18 or higher and the irc network supports it, you can use SASL instead of nickserv, which is more reliable:
 
+     /NETWORK ADD -sasl_username yourname -sasl_password yourpassword -sasl_mechanism PLAIN Freenode
+
+These commands have many more options, see their help for details:
+
+     /HELP NETWORK
+     /HELP SERVER
+     /HELP CHANNEL
+     /HELP
 
 If you want lines containing your nick to hilight:
 
-
      /HILIGHT nick
+
+Or, for irssi 0.8.18 or higher:
+
+     /SET hilight_nick_matches_everywhere ON
 
 
 ## 2\. Basic user interface usage

--- a/documentation/startup/index.markdown
+++ b/documentation/startup/index.markdown
@@ -111,7 +111,7 @@ Mac OS X users with ALT key issues might prefer using [iTerm2][iterm] instead of
 
 ### Alt key as meta, for xterm/rxvt users
 
-If you use xterm or rxvt, you may need to few X resources:
+If you use xterm or rxvt, you may need to set a few X resources:
 
 
      XTerm*eightBitInput:   false

--- a/documentation/startup/index.markdown
+++ b/documentation/startup/index.markdown
@@ -526,7 +526,13 @@ Irssi proxy works fine with other IRC clients as well.
 
 **SOCKS**
 
-Irssi can be compiled with socks support (`\--with-socks` option to configure), but I don't really know how it works, if at all. `/SET proxy` settings don't have anything to do with socks however.
+Irssi can be compiled with socks support (`\--with-socks` option to configure), which requires "dante" and routes all connections through the proxy specified in the system-wide /etc/socks.conf. This method is known to have issues in Mac OS X.
+
+Note that `/SET proxy` settings don't have anything to do with socks.
+
+Using [proxychains-ng][] is recommended over recompiling irssi.
+
+[proxychains-ng]: https://github.com/rofl0r/proxychains-ng
 
 **Others**
 

--- a/documentation/startup/index.markdown
+++ b/documentation/startup/index.markdown
@@ -11,8 +11,7 @@ Copyright (c) 2000-2002 by Timo Sirainen, release under [GNU FDL][1] 1.1 license
 
 Index with some FAQ questions that are answered in the chapter:
 
-1. [For all the ircII people](#for-all-the-ircii-people)
-    * This window management is just weird, I want it exactly like ircII
+1. [First steps](#first-steps)
 2. [Basic user interface usage](#basic-user-interface-usage)
     * Split windows work in weird way
     * How can I easily switch between windows?
@@ -35,49 +34,11 @@ Index with some FAQ questions that are answered in the chapter:
     * How do I make F1 key do something?
 10. [Proxies and IRC bouncers](#proxies-and-irc-bouncers)
 11. [Irssi's settings](#irssis-settings)
+    * [For all the ircII people](#for-all-the-ircii-people)
 12. [Statusbar](#statusbar)
     * I loaded a statusbar script but it's not visible anywhere!
 
-## 1\. For all the ircII people
-
-These settings should give you pretty good defaults (the ones I use):
-
-If colors don't work, and you know you're not going to use some weird non-VT compatible terminal (you most probably aren't), just say:
-
-
-     /SET term_force_colors ON
-
-
-I don't like automatic query windows, I don't like status window, I do like msgs window where all messages go:
-
-
-     /SET autocreate_own_query OFF
-     /SET autocreate_query_level DCCMSGS
-     /SET use_status_window OFF
-     /SET use_msgs_window ON
-
-
-Disable automatic window closing when `/PART`ing channel or `/UNQUERY`ing query:
-
-
-     /SET autoclose_windows OFF
-     /SET reuse_unused_windows ON
-
-
-Here's the settings that make irssi work exactly like ircII in window management (send me a note if you can think of more):
-
-
-     /SET autocreate_own_query OFF
-     /SET autocreate_query_level NONE
-     /SET use_status_window OFF
-     /SET use_msgs_window OFF
-     /SET reuse_unused_windows ON
-     /SET windows_auto_renumber OFF
-
-     /SET autostick_split_windows OFF
-     /SET autoclose_windows OFF
-     /SET print_active_channel ON
-
+## 1\. First steps
 
 And example how to add servers:
 
@@ -659,6 +620,38 @@ You probably don't like Irssi's default settings. I don't like them. But I'm sti
 
 /SET completion_char :
 : Completion character to use.
+
+### For all the ircII people
+
+I don't like automatic query windows, I don't like status window, I do like msgs window where all messages go:
+
+
+     /SET autocreate_own_query OFF
+     /SET autocreate_query_level DCCMSGS
+     /SET use_status_window OFF
+     /SET use_msgs_window ON
+
+
+Disable automatic window closing when `/PART`ing channel or `/UNQUERY`ing query:
+
+
+     /SET autoclose_windows OFF
+     /SET reuse_unused_windows ON
+
+
+Here's the settings that make irssi work exactly like ircII in window management (send me a note if you can think of more):
+
+
+     /SET autocreate_own_query OFF
+     /SET autocreate_query_level NONE
+     /SET use_status_window OFF
+     /SET use_msgs_window OFF
+     /SET reuse_unused_windows ON
+     /SET windows_auto_renumber OFF
+
+     /SET autostick_split_windows OFF
+     /SET autoclose_windows OFF
+     /SET print_active_channel ON
 
 ## 12\. Statusbar
 

--- a/documentation/startup/index.markdown
+++ b/documentation/startup/index.markdown
@@ -84,6 +84,11 @@ Or, for irssi 0.8.18 or higher:
 
      /SET hilight_nick_matches_everywhere ON
 
+To get beeps on private messages or highlights:
+
+     /SET beep_msg_level MSGS HILIGHT DCCMSGS
+
+No other irssi settings are needed (don't enable bell_beeps), but there may be settings to change in your terminal multiplexer (screen/tmux), your terminal, or your desktop environment.
 
 ## 2\. Basic user interface usage
 

--- a/documentation/startup/index.markdown
+++ b/documentation/startup/index.markdown
@@ -89,7 +89,7 @@ Or, for irssi 0.8.18 or higher:
 
 Windows can be scrolled up/down with PgUp and PgDown keys. If they don't work for you, use Meta-p and Meta-n keys. For jumping to beginning or end of the buffer, use `/SB HOME` and `/SB END` commands.
 
-By default, irssi uses "hidden windows" for everything. Hidden window is created every time you `/JOIN` a channel or `/QUERY` someone. There's several ways you can change between these windows:
+By default, irssi uses "hidden windows" for everything. Hidden windows are created every time you `/JOIN` a channel or `/QUERY` someone. There's several ways you can change between these windows:
 
 
      Meta-1, Meta-2, .. Meta-0 - Jump directly between windows 1-10
@@ -98,7 +98,15 @@ By default, irssi uses "hidden windows" for everything. Hidden window is created
      Ctrl-P, Ctrl-N            - Jump to previous / next window
 
 
-Clearly the easiest way is to use Meta-number keys. And what is the Meta key? ESC key always works as Meta, but there's also easier ways. ALT could work as Meta, or if you have Windows keyboard, left Windows key might work as Meta. If they don't work directly, you'll need to set a few X resources (NOTE: these work with both xterm and rxvt):
+Clearly the easiest way is to use Meta-number keys. Meta usually means the ALT key, but if that doesn't work, you can use ESC.
+
+Mac OS X users with ALT key issues might prefer using [iTerm2][iterm] instead of the default terminal emulator.
+
+[iterm]: https://www.iterm2.com/
+
+### Alt key as meta, for xterm/rxvt users
+
+If you use xterm or rxvt, you may need to few X resources:
 
 
      XTerm*eightBitInput:   false
@@ -119,7 +127,11 @@ You could do this by changing the X key mappings:
 
 And how exactly do you set these X resources? For Debian, there's `/etc/X11/Xresources/xterm` file where you can put them and it's read automatically when X starts. `~/.Xresources` and `~/.Xdefaults` files might also work. If you can't get anything else to work, just copy and paste those lines to `~/.Xresources` and directly call `xrdb -merge ~/.Xresources` in some xterm. The resources affect only the new xterms you start, not existing ones.
 
-Many windows SSH clients also don't allow usage of ALT. One excellent client that does allow is putty, you can download it from [ http://www.chiark.greenend.org.uk/~sgtatham/putty/][2].
+### Split windows and window items
+
+*Note: [this guide][quadpoint] might be a better introduction to window splits*
+
+[quadpoint]: http://quadpoint.org/articles/irssisplit/
 
 Irssi also supports split windows, they've had some problems in past but I think they should work pretty well now :) Here's some commands related to them:
 
@@ -175,7 +187,7 @@ If you want to group only some channels or queries in one window, use
 
 Irssi's multiple IRC network support is IMHO very good - at least compared to other clients :) Even if you're only in one IRC network you should group all your servers to be in the same IRC network as this helps with reconnecting if your primary server breaks and is probably useful in some other ways too :) For information how to actually use irssi correctly with multiple servers see the chapter 6.
 
-First you need to have your IRC network set, use `/NETWORK` command to see if it's already there. If it isn't, use `/NETWORK ADD yournetwork`. If you want to execute some commands automatically when you're connected to some network, use `-autosendcmd` option. (NOTE: use /IRCNET with 0.8.9 and older.) Here's some examples:
+First you need to have your IRC network set, use `/NETWORK` command to see if it's already there. If it isn't, use `/NETWORK ADD yournetwork`. If you want to execute some commands automatically when you're connected to some network, use `-autosendcmd` option. Here's some examples:
 
 
      /NETWORK ADD -autosendcmd '^msg bot invite' IRCnet
@@ -479,8 +491,6 @@ psyBNC has internal support for multiple servers. However, it could be a bit ann
 
 So, you'll specify the usernames with `/NETWORK ADD` command, and the user's password with `/SERVER ADD`.
 
-(NOTE: use /IRCNET with 0.8.9 and older.)
-
 **Irssi proxy**
 
 Irssi contains it's own proxy which you can build giving `\--with-proxy` option to configure. You'll still need to run irssi in a screen to use it though.
@@ -537,7 +547,7 @@ The proxy_string is sent before NICK/USER commands, the proxy_string_after is se
 
 ## 11\. Irssi's settings
 
-You probably don't like Irssi's default settings. I don't like them. But I'm still convinced that they're pretty good defaults. Here's some of them you might want to change (the default value is shown): Also check the [Settings Documentation](/documentation/settings/)
+Here's some settings you might want to change (the default value is shown): Also check the [Settings Documentation](/documentation/settings/)
 
 **Queries**
 

--- a/documentation/tips/index.markdown
+++ b/documentation/tips/index.markdown
@@ -24,10 +24,7 @@ to get notified off activities, while im working, i use the following setup:
 
 #### irssi
 
-    /set beep_when_window_active ON
-    /set beep_when_away ON
-    /set beep_msg_level MSGS NOTICES DCC DCCMSGS HILIGHT
-    /set bell_beeps ON
+    /set beep_msg_level MSGS HILIGHT DCCMSGS
 
 
 #### screen


### PR DESCRIPTION
Mainly getting the ircII window management nonsense out of the way. Moved to the bottom if anyone cares. Also reorganized the whole first section to have useful stuff and tweaked the second section a little. The rest is removing dust (lol "with 0.8.9 and older").
