### PR TITLE
Replace apt-get by apt

### DIFF
--- a/download/index.markdown
+++ b/download/index.markdown
@@ -52,7 +52,7 @@ Download setup.exe from [Cygwin][2]{:rel='external'} and select irssi during the
 
 ### Debian
 
-`apt-get install irssi`.  
+`apt install irssi`.  
 You may find more up to date version on [Debian Backports][5]{:rel='external'}
 
 [5]: http://backports.debian.org/
@@ -62,7 +62,7 @@ You may find more up to date version on [Debian Backports][5]{:rel='external'}
 
 ### Ubuntu
 
-`apt-get install irssi`.  
+`apt install irssi`.  
 
 </div>
 <div class="info about-macosx" markdown="1">


### PR DESCRIPTION
Hi,

I just updated the doc and replaced `apt-get` by `apt`.

> APT is a vast project, whose original plans included a graphical interface. It is based on a library which contains the core application, and apt-get is the first front end — command-line based — which was developed within the project. apt is a second command-line based front end provided by APT which overcomes some design mistakes of apt-get.

From [The Debian Administrator's Handbook](https://debian-handbook.info/browse/stable/sect.apt-get.html).

Cheers !