### PR TITLE
xterm-color is obsolete, use xterm-256color instead

### DIFF
--- a/documentation/faq.markdown
+++ b/documentation/faq.markdown
@@ -5,7 +5,7 @@ permalink: documentation/faq/
 ---
 ### Q: Why doesn't irssi display colors even when ircii etc. displays them?
 
-A: They force ANSI colors even if terminal doesn't support them. By default, irssi uses colors only if terminfo/termcap so says. The correct way to fix this would be to change your TERM environment to a value where colors work, like xterm-color or color_xterm (eg. `TERM=xterm-color irssi`). If this doesn't help, then use the evil way of `/SET term_force_colors ON`.
+A: They force ANSI colors even if terminal doesn't support them. By default, irssi uses colors only if terminfo/termcap so says. The correct way to fix this would be to change your TERM environment to a value where colors work, like xterm-256color or color_xterm (eg. `TERM=xterm-256color irssi`). If this doesn't help, then use the evil way of `/SET term_force_colors ON`.
 
 ### Q: How do I easily write text to channel that starts with '/' character?
 


### PR DESCRIPTION
The xterm-color is an older version of XTerm which only supports eight colours, whereas xterm-256 has support for 256 colours enabled. I modified the FAQ page to reflect this.