### PR TITLE
Update mini_intro.html

### DIFF
--- a/_includes/mini_intro.html
+++ b/_includes/mini_intro.html
@@ -4,4 +4,4 @@
     range of available extensions.</p>
   <p>Integrates into the UNIX stack: Your window manager, your terminal emulator, your remote connection, your terminal multiplexer, your IRC bouncer, your IRC adapter.
   </p>
-  <p>Irssi is free software licensed under the GPLv2, available for Linux, BSD, Solaris, Apple, Cygwin, &hellip;</p>
+  <p>Irssi is free software licensed under the GPLv2, available for Linux, BSD, Solaris, Haiku, Apple, Cygwin, &hellip;</p>


### PR DESCRIPTION
`irssi` is also available for [Haiku](https://github.com/haikuports/haikuports/blob/master/net-irc/irssi/irssi-1.2.3.recipe). It would be nice to have it for making Haiku name better known. Thanks for considering.