### PR TITLE
Specify that client authentication certificates must be available as files

### DIFF
--- a/sphinx/documentation/qna/certfp.md
+++ b/sphinx/documentation/qna/certfp.md
@@ -11,3 +11,5 @@ In order to use it, you
 Irssi does not have built-in certificate management commands, so you need to use an external tool like `openssl` to create the certificate.
 
 A step-by-step guide for the Libera Chat network can be found here => https://github.com/shabble/irssi-docs/wiki/liberachat_certfp
+
+It is necessary that the certificate be available as a file; PKCS#11 is not supported.


### PR DESCRIPTION
Security keys are not supported.