### PR TITLE
Document how to disable show_names_on_join_limit

### DIFF
--- a/sphinx/documentation/settings.md
+++ b/sphinx/documentation/settings.md
@@ -785,6 +785,8 @@ See the [appendix](#a-credits) for credits and license information of this docum
 
 : Do not show the NAMES list on join if there are more than show_names_on_join_limit users in the channel.
 
+  Set to -1 to disable.
+
   Added in Irssi 1.3
 
 (show_extended_join)=


### PR DESCRIPTION
Setting to 0 works as well but the release announcement used -1 so I used that here as well.

https://github.com/irssi/irssi/blob/0697e3eaf14ab5c0d6529d883475f327bad59e73/src/fe-common/core/fe-channels.c#L113