### PR TITLE
Add matrirc to Protocol Modules

### DIFF
--- a/sphinx/modules.md
+++ b/sphinx/modules.md
@@ -5,6 +5,7 @@ These third-party modules come **without any support or warranty** from the Irss
 ## Protocol Modules
 * IRC (built-in)
 * [Matrix](https://codeberg.org/ticho/irssi-matrix/) (under development)
+* [Matrix](https://github.com/pawelb0/matrirc) via matrirc — local IRC server bridging Matrix with E2EE
 * [Rocket.Chat](https://github.com/jajm/irssi-rocketchat) (under development)
 * [ICB](https://github.com/mglocker/irssi-icb)
 * [SILC](http://www.silcnet.org/)


### PR DESCRIPTION
## What
- Add matrirc entry to Protocol Modules alongside existing Matrix line
- matrirc is a local IRC server bridging Matrix; not an irssi plugin

## Checks
- Docs-only; sphinx build unaffected